### PR TITLE
Use region host + port instead of object for sleep

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -88,7 +88,8 @@ class RegionServerException(PyBaseException):
                     main_client._purge_client(self.region_client)
                     # Sleep for an arbitrary amount of time. If this returns
                     # False then we've hit our max retry threshold. Die.
-                    if not _dynamic_sleep(self, self.region_client):
+                    key = self.region_client.host + ':' + self.region_client.port
+                    if not _dynamic_sleep(self, key):
                         raise self
             # Notify all the other threads to wake up because we've handled the
             # exception for everyone!


### PR DESCRIPTION
Dynamic sleep wasn't working with `RegionServerException` because it was using the region client object as key in `_exception_count`. The object changes on each iteration so the sleep is not dynamic and we enter a cycle. Using the region client's host and port as key to avoid this.

@CurleySamuel @hzhaofb @dcreemer  
